### PR TITLE
fix: fix rollup 4.0 hook

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { readFile } from 'fs'
+import { readFile, write } from 'fs'
 import { createServer as createHttpsServer } from 'https'
 import { createServer } from 'http'
 import { resolve } from 'path'
@@ -100,7 +100,7 @@ export default function serve(options = { contentBase: '' }) {
 
   return {
     name: 'serve',
-    ongenerate() {
+    writeBundle() {
       if (!running) {
         running = true
 


### PR DESCRIPTION
hi,i find a bug:
now rollup version is update to v.4.0+
when i use this pulgin, the default bowser cant open self
reason is your rollup hook：ongenerate
should be modified into writeBundle  it can work~
![image](https://github.com/user-attachments/assets/564b7551-01bf-4274-a29d-fe08ee073469)
